### PR TITLE
Merge pull request #11 from saraedum/flint

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
    - extern-kill.patch
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage("normaliz") }}
@@ -33,6 +33,7 @@ requirements:
     - mpir                 # [win]
     - llvm-openmp          # [osx or win]
     - e-antic              # [not win]
+    - libflint             # [not win]
     - nauty
     - pthreads-win32       # [win]
   run:


### PR DESCRIPTION
when building with the e-antic C++ headers since they pull in FLINT
explicitly

see #10.