### PR TITLE
Normaliz links against arb

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -1,3 +1,5 @@
+arb:
+- '2.17'
 boost_cpp:
 - 1.70.0
 c_compiler:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,5 +1,7 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
+arb:
+- '2.17'
 boost_cpp:
 - 1.70.0
 c_compiler:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,3 +1,5 @@
+arb:
+- '2.17'
 boost_cpp:
 - 1.70.0
 c_compiler:

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+arb:
+- '2.17'
 boost_cpp:
 - 1.70.0
 c_compiler:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - extern-kill.patch
 
 build:
-  number: 2
+  number: 3
   skip: True  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage("normaliz") }}
@@ -33,7 +33,6 @@ requirements:
     - mpir                 # [win]
     - llvm-openmp          # [osx or win]
     - e-antic              # [not win]
-    - arb =2.16            # [not win]
     - libflint             # [not win]
     - arb                  # [not win]
     - nauty

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,10 +9,10 @@ source:
   url: https://github.com/Normaliz/Normaliz/releases/download/v{{ version }}/normaliz-{{ version }}-full.zip
   sha256: 89d4551a8d527623768cea2e265200af35b896ab5e70352940769b7408bad3e1
   patches:
-   - extern-kill.patch
+    - extern-kill.patch
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage("normaliz") }}
@@ -28,13 +28,13 @@ requirements:
     - libtool              # [not win]
     - make                 # [not win]
   host:
-    - libflint             # [not win]
     - boost-cpp
     - gmp                  # [not win]
     - mpir                 # [win]
     - llvm-openmp          # [osx or win]
     - e-antic              # [not win]
     - libflint             # [not win]
+    - arb                  # [not win]
     - nauty
     - pthreads-win32       # [win]
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
    - extern-kill.patch
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage("normaliz") }}
@@ -28,12 +28,12 @@ requirements:
     - libtool              # [not win]
     - make                 # [not win]
   host:
-    - libflint             # [not win]
     - boost-cpp
     - gmp                  # [not win]
     - mpir                 # [win]
     - llvm-openmp          # [osx or win]
     - e-antic              # [not win]
+    - arb =2.16            # [not win]
     - libflint             # [not win]
     - nauty
     - pthreads-win32       # [win]


### PR DESCRIPTION
because it's used in output.cpp.

Fixes #10.